### PR TITLE
Supporting same endpoint in different schemas.

### DIFF
--- a/openapi-merger-app/src/main/kotlin/com/rameshkp/openapi/merger/app/mergers/PathsMerger.kt
+++ b/openapi-merger-app/src/main/kotlin/com/rameshkp/openapi/merger/app/mergers/PathsMerger.kt
@@ -1,5 +1,6 @@
 package com.rameshkp.openapi.merger.app.mergers
 
+import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.Paths
 import org.slf4j.LoggerFactory
 
@@ -13,10 +14,40 @@ class PathsMerger: Mergeable<Paths> {
     override fun merge(from: Paths?) {
         from?.run {
             forEach { entry ->
-                if (paths.containsKey(entry.key)) {
-                    log.warn("Path entry for {} already exists. Hence skipping", entry.key)
-                } else {
+                val existingPathItem: PathItem? = paths[entry.key]
+                val pathItem: PathItem = entry.value
+                if (existingPathItem == null) {
                     paths[entry.key] = entry.value
+                } else {
+                    existingPathItem.run {
+
+                        fun <T> setPropertyOnExistingPathItemIfMissing(
+                            propertyName: String,
+                            getProperty: (it: PathItem) -> T?,
+                            setValueOnExistingPathItem: (value: T?) -> Unit
+                        ) {
+                            if (getProperty(existingPathItem) == null) {
+                                setValueOnExistingPathItem(getProperty(pathItem))
+                            } else if (getProperty(pathItem) != null) {
+                                log.warn("{} in path entry for {} already exists. Hence skipping", propertyName, entry.key)
+                            }
+                        }
+
+                        setPropertyOnExistingPathItemIfMissing("description", {it.description}, {existingPathItem.description = it})
+                        setPropertyOnExistingPathItemIfMissing("summary", {it.summary}, {existingPathItem.summary = it})
+                        setPropertyOnExistingPathItemIfMissing("get", {it.get}, {existingPathItem.get = it})
+                        setPropertyOnExistingPathItemIfMissing("put", {it.put}, {existingPathItem.put = it})
+                        setPropertyOnExistingPathItemIfMissing("post", {it.post}, {existingPathItem.post = it})
+                        setPropertyOnExistingPathItemIfMissing("delete", {it.delete}, {existingPathItem.delete = it})
+                        setPropertyOnExistingPathItemIfMissing("options", {it.options}, {existingPathItem.options = it})
+                        setPropertyOnExistingPathItemIfMissing("head", {it.head}, {existingPathItem.head = it})
+                        setPropertyOnExistingPathItemIfMissing("patch", {it.patch}, {existingPathItem.patch = it})
+                        setPropertyOnExistingPathItemIfMissing("trace", {it.trace}, {existingPathItem.trace = it})
+                        setPropertyOnExistingPathItemIfMissing("servers", {it.servers}, {existingPathItem.servers = it})
+                        setPropertyOnExistingPathItemIfMissing("parameters", {it.parameters}, {existingPathItem.parameters = it})
+                        setPropertyOnExistingPathItemIfMissing("ref", {it.`$ref`}, {existingPathItem.`$ref` = it})
+                        setPropertyOnExistingPathItemIfMissing("extensions", {it.extensions}, {existingPathItem.extensions = it})
+                    }
                 }
             }
         }


### PR DESCRIPTION
For instance one api-spec could have `GET /books` and another api-spec could have `POST /books`. This can now be merged with this change.

It is the issue described in more detail here: https://github.com/kpramesh2212/openapi-merger-plugin/issues/7

This PR is donated by JYSK A/S :)